### PR TITLE
Check to see if the user is actually a superadmin before returning true

### DIFF
--- a/src/Traits/HasRolesAndPermissions.php
+++ b/src/Traits/HasRolesAndPermissions.php
@@ -18,11 +18,11 @@ trait HasRolesAndPermissions
     public function hasPermission($permission)
     {
         $permission = !is_string($permission) ?: Permission::where(['slug' => $permission])->first();
-        
+
         if (config('laralum.superadmin_bypass_haspermission') && in_array(Auth::user()->email, config('laralum.superadmins'))) {
             return true;
         }
-        
+
         if ($permission) {
             foreach ($this->roles as $role) {
                 if ($role->hasPermission($permission)) {

--- a/src/Traits/HasRolesAndPermissions.php
+++ b/src/Traits/HasRolesAndPermissions.php
@@ -19,7 +19,7 @@ trait HasRolesAndPermissions
     {
         $permission = !is_string($permission) ?: Permission::where(['slug' => $permission])->first();
         
-        if (config('laralum.superadmin_bypass_haspermission')) {
+        if (config('laralum.superadmin_bypass_haspermission') && in_array(Auth::user()->email, config('laralum.superadmins'))) {
             return true;
         }
         


### PR DESCRIPTION
Prior to this commit, if the "laralum.superadmin_bypass_haspermission" config option was set to true, this conditional would *always* return true, regardless of whether or not the user was actually a super admin.  Now it checks to make sure the requesting user is actually a superadmin before returning true.